### PR TITLE
Got basic backtracing working on ARM64 running Linux.

### DIFF
--- a/pkg/proc/arm64_linux_stack.go
+++ b/pkg/proc/arm64_linux_stack.go
@@ -1,0 +1,68 @@
+package proc
+
+import (
+	"unsafe"
+)
+
+// The following code is specific to Linux and and the ARM64.  It sees if the
+// current return address points to the return-from-exception system call.
+// If so, it will locate the previous stack frame and it will set the CFA to
+// point to this previous stack frame.  It seems likely that code similar to
+// this will be useful for other architectures.  
+//
+// This code was adapted from "gdb".
+//
+// It might be possible to eliminate the offsets below by referring to
+// Dwarf symbols and/or exception routine name lookups.  For now, this will
+// have to wait until ARM64 Delve can more reliably look up local stack
+// variables.  Another (less satisfactory) way would be to duplicate Linux's
+// runtime exception structure's layouts, which is what gdb does.
+//
+// It might be good to put a "tag" into the stack structure indicating
+// when a frame is an "exception" frame, and hence "jumps".  Further,
+// exception frames contain the registers at the time of the exception.
+// When a GO program is compiled without debugging symbols, this register
+// structure should be used to fetch saved registers, thus allowing Delve
+// to print variables from previous frames that were still in registers
+// at the time of the procedure calls.
+
+func checkException_linux_arm64(it *stackIterator, ret *uint64) {
+	const sigreturn0 = 0xd2801168	// movz x8, 0x8b    (return from
+	const sigreturn4 = 0xd4000001	// svc  0x0          exception)
+
+	const go_frame_size = 0x800		// size of Go's signal stack frame
+	const offset_to_sp  = 0x02f		// offset to saved SP in signal's save area
+
+	inst_size := int64(uintptr(unsafe.Sizeof(uint32(0))))
+
+	// See if the current return is to a return-from-execption system call.
+
+	val, err := readUintRaw(it.mem, uintptr(*ret), inst_size)
+	if err != nil || val != sigreturn0 {
+		return
+	}
+	val, err = readUintRaw(it.mem, uintptr(*ret+uint64(inst_size)), inst_size)
+	if (err != nil || val != sigreturn4) {
+		return
+	}
+
+	// Here we assume that the signal's register save area is located just below
+	// the end of the stack frame that Go has reserved for this signal.  From this
+	// register save area fetch the value of the SP at the time of the signal.
+	// This SP is now the new CFA.
+
+	val = (uint64(it.regs.CFA) | (go_frame_size-1)) - offset_to_sp
+	val1, err := readUintRaw(it.mem, uintptr(val), int64(it.bi.Arch.PtrSize()))
+	if err != nil {
+		return
+	}
+	it.regs.CFA = int64(val1)
+
+	// Read the return address.
+
+	val2, err := readUintRaw(it.mem, uintptr(it.regs.CFA), int64(it.bi.Arch.PtrSize()))
+	if err != nil {
+		return
+	}
+	*ret = val2
+}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -118,6 +118,13 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 			addr := afterLastArgAddr(vars)
 			if addr == 0 {
 				addr = uintptr(scope.Regs.CFA)
+				// The address needed on the ARM64 by the Dwarf lookup routines
+				// is offset from scope.Regs.CFA by the length of a 64-bit
+				// pointer.  This is corrected here.  It probably would be better
+				// to store the corrected address in scope.Regs.CFA.
+				if _, isARM64 := scope.BinInfo.Arch.(*ARM64); isARM64 {
+					addr = addr + uintptr(scope.PtrSize())
+				}
 			}
 			addr = uintptr(alignAddr(int64(addr), val.DwarfType.Align()))
 			val = newVariable(val.Name, addr, val.DwarfType, scope.BinInfo, scope.Mem)

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -5,11 +5,20 @@ import (
 	"errors"
 	"fmt"
 	"go/constant"
+	"sort"
 
 	"github.com/go-delve/delve/pkg/dwarf/frame"
 	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/dwarf/reader"
 )
+
+// Define a list of key indicies.  This is used to call the sort package.
+
+type keyList []uint64
+
+func (a keyList) Len() int           { return len(a) }
+func (a keyList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a keyList) Less(i, j int) bool { return a[i] < a[j] }
 
 // This code is partly adapted from runtime.gentraceback in
 // $GOROOT/src/runtime/traceback.go
@@ -438,13 +447,24 @@ func (it *stackIterator) advanceRegs() (callFrameRegs op.DwarfRegisters, ret uin
 	// implicit.
 	// See also the comment in dwarf2_frame_default_init in
 	// $GDB_SOURCE/dwarf2-frame.c
-	if _, ok := it.bi.Arch.(*ARM64); ok {
+	_, isARM64 := it.bi.Arch.(*ARM64)
+	if isARM64 {
 		callFrameRegs.AddReg(uint64(arm64DwarfSPRegNum), cfareg)
 	} else {
 		callFrameRegs.AddReg(uint64(amd64DwarfSPRegNum), cfareg)
 	}
 
-	for i, regRule := range framectx.Regs {
+	// Sort the key indicies in "framectx.Regs".  On the ARM64, if index 31 is
+	// returned before index 30, the backtrace always messes up on exception
+	// records.  This happens about 12% of the time due to GO's randomization
+	// of indecies on for loops over ranges on maps.
+	var keys keyList
+	for i := range framectx.Regs {
+		keys = append(keys, i)
+	}
+	sort.Sort(keys)
+	for _, i := range keys {
+		regRule := framectx.Regs[i]
 		reg, err := it.executeFrameRegRule(i, regRule, it.regs.CFA)
 		callFrameRegs.AddReg(i, reg)
 		if i == framectx.RetAddrReg {
@@ -455,12 +475,15 @@ func (it *stackIterator) advanceRegs() (callFrameRegs op.DwarfRegisters, ret uin
 				it.err = err
 			} else {
 				ret = reg.Uint64Val
+				if isARM64 && it.bi.GOOS == "linux" {
+					checkException_linux_arm64(it, &ret)
+				}
 			}
 			retaddr = uint64(it.regs.CFA + regRule.Offset)
 		}
 	}
 
-	if _, ok := it.bi.Arch.(*ARM64); ok {
+	if isARM64 {
 		if ret == 0 && it.regs.Regs[it.regs.LRRegNum] != nil {
 			ret = it.regs.Regs[it.regs.LRRegNum].Uint64Val
 		}


### PR DESCRIPTION
Got an improved version of backtracing going for the ARM64 version of GO
running under Linux.  It now handles exception records for GO versions
1.12, 1.13, and 1.14 (and probably also works for earlier version),
and is less dependent upon the GO runtime code.

Also fixed a bug that would cause bactraces to fail around 12% of the time.

Fixed a bug that caused most arguments to GO routines to be printed out
incorrectly.